### PR TITLE
Replace ngrok with bore (no account or token needed)

### DIFF
--- a/.github/workflows/Windows-latest.yml
+++ b/.github/workflows/Windows-latest.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - name: Download
-      run: Invoke-WebRequest https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-windows-amd64.zip -OutFile ngrok.zip
-    - name: Extract
-      run: Expand-Archive ngrok.zip
-    - name: Auth
-      run: .\ngrok\ngrok.exe config add-authtoken ${{ secrets.NGROK_TOKEN }}
+    - name: Download bore
+      run: |
+        $api = Invoke-RestMethod "https://api.github.com/repos/ekzhang/bore/releases/latest"
+        $url = ($api.assets | Where-Object { $_.name -match "windows" -and $_.name -match "\.zip" } | Select-Object -First 1).browser_download_url
+        Invoke-WebRequest $url -OutFile bore.zip
+        Expand-Archive bore.zip -DestinationPath .
     - name: Enable TS
       run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server'-name "fDenyTSConnections" -Value 0
     - run: Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
     - run: Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -name "UserAuthentication" -Value 1
     - run: Set-LocalUser -Name "runneradmin" -Password (ConvertTo-SecureString -AsPlainText "P@ssw0rd!" -Force)
     - name: Create Tunnel
-      run: .\ngrok\ngrok.exe tcp 3389
+      run: .\bore.exe local 3389 --to bore.pub


### PR DESCRIPTION
I saw that the Windows RDP thing needs a paid ngrok account for those TCP tunnels. It kind of locks out a lot of people who do not want to pay. So I switched it over to bore instead. Bore is free and open source, and it does pretty much the same job without any account or token or setup hassle. 

The workflow handles downloading the newest bore file on its own. Then it sets up the tunnel and shows something like bore.pub:PORT right in the logs. You just grab that and connect with your RDP client, no problem. 

It feels like the same setup as before, but now its totally free for anyone. I think that makes a difference, though maybe not everyone will notice right away.